### PR TITLE
Fix model state and table name mismatch on view re-creation

### DIFF
--- a/django_db_views/operations.py
+++ b/django_db_views/operations.py
@@ -43,6 +43,10 @@ class ViewRunPython(operations.RunPython):
                 model = DBView
             else:
                 raise NotImplementedError
+
+            if app_label not in self.code.table_name:
+                app_label = "_".join(self.code.table_name.split("_")[:-1])
+
             state.add_model(
                 DBViewModelState(
                     app_label,
@@ -72,12 +76,8 @@ class ViewDropRunPython(operations.RunPython):
         if VIEW_MIGRATION_CONTEXT["is_view_migration"]:
             if app_label not in self.code.table_name:
                 app_label = "_".join(self.code.table_name.split("_")[:-1])
-                table_name = self.code.table_name.split("_")[-1]
-            else:
-                table_name = get_table_engine_name_hash(
-                    self.code.table_name, self.code.view_engine
-                )
+
             state.remove_model(
                 app_label,
-                table_name,
+                get_table_engine_name_hash(self.code.table_name, self.code.view_engine),
             )


### PR DESCRIPTION
Adding the `app_label` logic to `ViewDropRunPython.state_forwards` ensures that the model state always puts the models under the correct app labels when re-creating views from one app (e.g. `smartkit`) in the migration for another app (e.g. `demand_response`).

The code  for `table_name = self.code.table_name.split("_")[-1]` was removed because that is inconsistent with the functionality when `app_label not in self.code.table_name` is false (in that case, the table name retains the app label prefix). If we want to instead use `table_name = self.code.table_name.split("_")[-1]` everywhere consistently, that can be done as well.